### PR TITLE
Fix build:standalone not finding the window object

### DIFF
--- a/src/client/lib/socket.js
+++ b/src/client/lib/socket.js
@@ -1,5 +1,5 @@
 /* global WebSocket, CustomEvent */
-import { createContext, useState, useContext } from 'react'
+import { createContext, useState, useContext, useEffect } from 'react'
 import notification from 'lib/notification'
 
 let socket = null// Store socket connection (defaults to null)
@@ -148,9 +148,11 @@ const SocketContext = createContext()
 function SocketProvider ({ children }) {
   const [socketState, setSocketState] = useState(defaultSocketState)
 
-  if (typeof WebSocket !== 'undefined' && socketState.connected !== true) {
-    connect(socketState, setSocketState)
-  }
+  useEffect(() => {
+    if (typeof WebSocket !== 'undefined' && socketState.connected !== true) {
+      connect(socketState, setSocketState)
+    }
+  });
 
   return (
     <SocketContext.Provider value={socketState}>


### PR DESCRIPTION
Building the service using `npm run build:standalone` fails and spams the log with errors such as

```
Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
ReferenceError: window is not defined
    at connect (icarus/src/client/.next/server/chunks/106.js:85:38)
    at SocketProvider (icarus/src/client/.next/server/chunks/106.js:230:9)
    at d (icarus/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:33:498)
    at bb (icarus/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:36:16)
    at b.render (icarus/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:42:43)
    at b.read (icarus/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:41:83)
    at exports.renderToString (icarus/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:52:138)
    at Object.renderPage (icarus/node_modules/next/dist/server/render.js:789:45)
    at Object.defaultGetInitialProps (icarus/node_modules/next/dist/server/render.js:393:51)
    at Document.getInitialProps (icarus/src/client/.next/server/chunks/331.js:547:20)
```

This PR resolves this by moving the offending call in a react useEffect call.