### PR TITLE
Add Linux remote ship controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ With that done, anytime you want to start ICARUS Terminal, all you need to do is
 
 This will run in debug mode which is not quite the same as a production build (it's not as optimised) but should work just fine.
 
+### Optional Linux ship controls
+
+When running ICARUS Terminal from source on Linux, ship switches in the remote
+web interface can optionally send keyboard input to Elite Dangerous. This is
+disabled by default and currently uses `xdotool`, so it requires an X11 session
+and `xdotool` installed on the computer running Elite Dangerous.
+
+To enable it, add this to your `.env` file:
+
+    ICARUS_ENABLE_CONTROLS=true
+
+ICARUS reads the active Elite Dangerous bindings file and enables supported
+switches when they have keyboard bindings. After changing bindings in-game, open
+`Settings -> Controls` in ICARUS and use `Refresh bindings`.
+
 ## Legal
 
 ICARUS Terminal is free, open-source software released under the ISC License.
@@ -122,4 +137,3 @@ You can use Inara to [find out which system the Ardent Pioneer is currently in](
 Before you visit you might want to [check out what commodities are currently 
 being traded](https://inara.cz/elite/station-market/490914/). You might also 
 want to chat to the bartender to see what they are looking for!
-

--- a/src/client/components/panels/ship/ship-status-panel.js
+++ b/src/client/components/panels/ship/ship-status-panel.js
@@ -1,7 +1,7 @@
 import { UNKNOWN_VALUE } from '../../../../shared/consts'
 import ShipInstrumentation from 'components/panels/ship/ship-status/ship-instrumentation'
 
-export default function ShipStatusPanel ({ ship, selectedModule, setSelectedModule, cmdrStatus, toggleSwitches, toggleSwitch }) {
+export default function ShipStatusPanel ({ ship, selectedModule, setSelectedModule, cmdrStatus, toggleSwitches, toggleSwitch, controlStatus }) {
   if (!ship) return null
 
   if (ship.type === UNKNOWN_VALUE && ship.name === UNKNOWN_VALUE && ship.ident === UNKNOWN_VALUE) {
@@ -30,8 +30,8 @@ export default function ShipStatusPanel ({ ship, selectedModule, setSelectedModu
             <h5 className='text-right text-info text-uppercase' style={{ position: 'absolute', right: '.5rem', opacity: ship.onBoard ? 1 : 0.5 }}>
               {ship.onBoard ? 'Online' : 'Offline'}
             </h5>
-            <div className={`ship-panel__horizontal-activity ${ship.onBoard ? 'ship-panel__horizontal-activity--online' : ''}`}/>
-            <div className='ship-panel__horizontal-activity-marker'/>
+            <div className={`ship-panel__horizontal-activity ${ship.onBoard ? 'ship-panel__horizontal-activity--online' : ''}`} />
+            <div className='ship-panel__horizontal-activity-marker' />
           </div>
         </div>
         <hr style={{ margin: '0 0 1rem 0' }} />
@@ -40,6 +40,7 @@ export default function ShipStatusPanel ({ ship, selectedModule, setSelectedModu
           cmdrStatus={cmdrStatus}
           toggleSwitches={toggleSwitches}
           toggleSwitch={toggleSwitch}
+          controlStatus={controlStatus}
         />
       </div>
     </>

--- a/src/client/components/panels/ship/ship-status/ship-instrumentation.js
+++ b/src/client/components/panels/ship/ship-status/ship-instrumentation.js
@@ -14,12 +14,13 @@ const applyScaling = (scaledWrapper, scaledContent) => {
   }
 }
 
-export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches, toggleSwitch }) {
+export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches, toggleSwitch, controlStatus }) {
   const scaledWrapper = useRef()
   const scaledContent = useRef()
 
   const panelActive = (ship.onBoard || cmdrStatus?.flags?.inSrv)
-  
+  const canToggleSwitch = (switchName) => ship.onBoard && !!controlStatus?.controls?.[switchName]?.key
+
   useEffect(async () => {
     const resizeEventHandler = () => {
       if (scaledWrapper.current && scaledContent.current) {
@@ -53,7 +54,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
           opacity: 0
         }}
       >
-          <table className={`ship-panel__switches table--layout ${!ship.onBoard ? 'text-muted' : ''}`}>
+          <table className={`ship-panel__switches table--layout ${!ship.onBoard ? 'text-muted' : ''}`} style={{ pointerEvents: 'auto' }}>
           <tbody>
             <tr>
               <td>
@@ -65,7 +66,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
                     type='checkbox'
                     checked={ship.onBoard && toggleSwitches?.lights}
                     onChange={() => toggleSwitch('lights')}
-                    disabled
+                    disabled={!canToggleSwitch('lights')}
                   />
                   <span className='checkbox__control' />
                 </label>
@@ -79,7 +80,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
                     type='checkbox'
                     checked={ship.onBoard && toggleSwitches?.nightVision}
                     onChange={() => toggleSwitch('nightVision')}
-                    disabled
+                    disabled={!canToggleSwitch('nightVision')}
                   />
                   <span className='checkbox__control' />
                 </label>
@@ -93,7 +94,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
                     type='checkbox'
                     checked={ship.onBoard && toggleSwitches?.cargoHatch}
                     onChange={() => toggleSwitch('cargoHatch')}
-                    disabled
+                    disabled={!canToggleSwitch('cargoHatch')}
                   />
                   <span className='checkbox__control' />
                 </label>
@@ -107,7 +108,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
                     type='checkbox'
                     checked={ship.onBoard && toggleSwitches?.landingGear}
                     onChange={() => toggleSwitch('landingGear')}
-                    disabled
+                    disabled={!canToggleSwitch('landingGear')}
                   />
                   <span className='checkbox__control' />
                 </label>
@@ -121,7 +122,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
                     type='checkbox'
                     checked={ship.onBoard && cmdrStatus?.flags?.supercruise === false && toggleSwitches?.hardpoints}
                     onChange={() => toggleSwitch('hardpoints')}
-                    disabled
+                    disabled={!canToggleSwitch('hardpoints') || cmdrStatus?.flags?.supercruise}
                   />
                   <span className='checkbox__control' />
                 </label>

--- a/src/client/components/panels/ship/ship-status/ship-instrumentation.js
+++ b/src/client/components/panels/ship/ship-status/ship-instrumentation.js
@@ -1,5 +1,13 @@
 import { useEffect, useRef } from 'react'
 
+const SWITCH_COMMANDS = {
+  lights: 'ShipSpotLightToggle',
+  nightVision: 'NightVisionToggle',
+  cargoHatch: 'ToggleCargoScoop',
+  landingGear: 'LandingGearToggle',
+  hardpoints: 'DeployHardpointToggle'
+}
+
 const applyScaling = (scaledWrapper, scaledContent) => {
   try {
     scaledContent.style.transform = 'scale(1, 1)'
@@ -19,7 +27,7 @@ export default function ShipInstrumentation ({ ship, cmdrStatus, toggleSwitches,
   const scaledContent = useRef()
 
   const panelActive = (ship.onBoard || cmdrStatus?.flags?.inSrv)
-  const canToggleSwitch = (switchName) => ship.onBoard && !!controlStatus?.controls?.[switchName]?.key
+  const canToggleSwitch = (switchName) => ship.onBoard && !!controlStatus?.controls?.[SWITCH_COMMANDS[switchName]]?.key
 
   useEffect(async () => {
     const resizeEventHandler = () => {

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -27,6 +27,7 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
         </div>
         {activeSettingsPanel === 'Theme' && <ThemeSettings visible={visible} />}
         {activeSettingsPanel === 'Sounds' && <SoundSettings visible={visible} />}
+        {activeSettingsPanel === 'Controls' && <ControlsSettings visible={visible} />}
         <div className='modal-dialog__footer'>
           <hr style={{ margin: '1rem 0 .5rem 0' }} />
           <button className='float-right' onClick={toggleVisible}>
@@ -35,6 +36,62 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
         </div>
       </div>
     </>
+  )
+}
+
+function ControlsSettings ({ visible }) {
+  const [controlStatus, setControlStatus] = useState()
+
+  const refreshBindings = async () => {
+    setControlStatus(await sendEvent('refreshBindings'))
+    document.activeElement.blur()
+  }
+
+  useEffect(async () => {
+    if (!visible) return
+    setControlStatus(await sendEvent('getControlStatus'))
+  }, [visible])
+
+  useEffect(() => eventListener('syncMessage', async (event) => {
+    if (event.name === 'controlStatus') {
+      setControlStatus(event.message)
+    }
+  }), [])
+
+  return (
+    <div className='modal-dialog__panel modal-dialog__panel--with-navigation scrollable'>
+      <h3 className='text-primary'>Controls</h3>
+      <p>
+        ICARUS can send keyboard input to Elite Dangerous for supported ship
+        switches. Keyboard bindings are read from the active Elite Dangerous
+        bindings file.
+      </p>
+      <h4 className='text-primary'>Elite Dangerous bindings</h4>
+      <p className='text-muted text-no-transform' style={{ wordBreak: 'break-word' }}>
+        {controlStatus?.bindingsFile || 'No active bindings file found'}
+      </p>
+      <table className='table--layout'>
+        <tbody>
+          {Object.entries(controlStatus?.controls || {}).map(([name, control]) => (
+            <tr key={`control_${name}`}>
+              <td className='text-primary text-uppercase'>{formatControlName(name)}</td>
+              <td className={control.key ? 'text-info' : 'text-muted'}>
+                {control.key ? `${control.key} (${control.source})` : 'No keyboard binding'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className='text-center' style={{ padding: '0.25rem 0' }}>
+        <button disabled={!controlStatus?.enabled} onClick={refreshBindings}>
+          <i className='icon icarus-terminal-sync' /> Refresh bindings
+        </button>
+      </div>
+      <p className='text-muted'>
+        If you change bindings in-game, refresh them here before using tablet
+        ship controls.
+      </p>
+    </div>
   )
 }
 
@@ -80,11 +137,13 @@ function SoundSettings ({ visible }) {
           }
         }}
       >
-        {voices && preferences && <>
-          <option value='None'>None</option>
-          <option disabled>─</option>
-          {voices && voices.map(voice => <option key={`voice_${voice}`}>{voice}</option>)}
-        </>}
+        {voices && preferences && (
+          <>
+            <option value='None'>None</option>
+            <option disabled>─</option>
+            {voices && voices.map(voice => <option key={`voice_${voice}`}>{voice}</option>)}
+          </>
+        )}
       </select>
       <br /><br />
       <h4 className='text-primary'>About voice assistant</h4>
@@ -276,6 +335,10 @@ function ThemeSettings () {
     </div>
   )
 }
+
+const formatControlName = (name) => name
+  .replace(/([A-Z])/g, ' $1')
+  .replace(/^./, firstLetter => firstLetter.toUpperCase())
 
 const hex2rgb = (hex) => {
   const r = parseInt(hex.slice(1, 3), 16)

--- a/src/client/components/settings.js
+++ b/src/client/components/settings.js
@@ -3,6 +3,14 @@ import { sendEvent, eventListener } from 'lib/socket'
 import { SettingsNavItems } from 'lib/navigation-items'
 import packageJson from '../../../package.json'
 
+const SHIP_SWITCH_CONTROLS = [
+  'ShipSpotLightToggle',
+  'NightVisionToggle',
+  'ToggleCargoScoop',
+  'LandingGearToggle',
+  'DeployHardpointToggle'
+]
+
 function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPanel = 'Theme' }) {
   const [activeSettingsPanel, setActiveSettingsPanel] = useState(defaultActiveSettingsPanel)
 
@@ -41,6 +49,7 @@ function Settings ({ visible, toggleVisible = () => {}, defaultActiveSettingsPan
 
 function ControlsSettings ({ visible }) {
   const [controlStatus, setControlStatus] = useState()
+  const switchControls = SHIP_SWITCH_CONTROLS.map((name) => [name, controlStatus?.controls?.[name]]).filter(([, control]) => control)
 
   const refreshBindings = async () => {
     setControlStatus(await sendEvent('refreshBindings'))
@@ -72,9 +81,9 @@ function ControlsSettings ({ visible }) {
       </p>
       <table className='table--layout'>
         <tbody>
-          {Object.entries(controlStatus?.controls || {}).map(([name, control]) => (
+          {switchControls.map(([name, control]) => (
             <tr key={`control_${name}`}>
-              <td className='text-primary text-uppercase'>{formatControlName(name)}</td>
+              <td className='text-primary text-uppercase'>{control.label || formatControlName(name)}</td>
               <td className={control.key ? 'text-info' : 'text-muted'}>
                 {control.key ? `${control.key} (${control.source})` : 'No keyboard binding'}
               </td>

--- a/src/client/lib/navigation-items.js
+++ b/src/client/lib/navigation-items.js
@@ -113,6 +113,10 @@ function SettingsNavItems (activePanel) {
     {
       name: 'Sounds',
       icon: 'sound'
+    },
+    {
+      name: 'Controls',
+      icon: 'ship'
     }
   ]
   navigationItems.forEach(item => {

--- a/src/client/pages/ship/modules.js
+++ b/src/client/pages/ship/modules.js
@@ -11,6 +11,7 @@ export default function ShipStatusPage () {
   const [ship, setShip] = useState()
   const [selectedModule, setSelectedModule] = useState()
   const [cmdrStatus, setCmdrStatus] = useState()
+  const [controlStatus, setControlStatus] = useState()
 
   // Using state for toggle switches like this allow us to have the UI
   // respond immediately to the input from the user, even if it takes the game
@@ -29,19 +30,21 @@ export default function ShipStatusPage () {
     if (!connected) return
     setShip(await sendEvent('getShipStatus'))
     setCmdrStatus(await sendEvent('getCmdrStatus'))
+    setControlStatus(await sendEvent('getControlStatus'))
   }, [connected, ready])
 
   const toggleSwitch = async (switchName) => {
+    if (!controlStatus?.controls?.[switchName]?.key) return
 
-    /*
-    // Only toggle switch value if we think it was successful
+    // Only toggle switch value if the local input backend accepted the command.
     const switchToggled = await sendEvent('toggleSwitch', { switchName })
 
-    setToggleSwitches({
-      ...toggleSwitches,
-      [switchName]: switchToggled ? !toggleSwitches[switchName] : toggleSwitches[switchName]
-    })
-    */
+    if (switchToggled) {
+      setToggleSwitches((previousSwitches) => ({
+        ...previousSwitches,
+        [switchName]: !previousSwitches[switchName]
+      }))
+    }
   }
 
   useEffect(async () => {
@@ -63,6 +66,12 @@ export default function ShipStatusPage () {
     setShip(await sendEvent('getShipStatus'))
     if (['Location', 'FSDJump'].includes(log.event)) {
       setCmdrStatus(await sendEvent('getCmdrStatus'))
+    }
+  }), [])
+
+  useEffect(() => eventListener('syncMessage', async (event) => {
+    if (event.name === 'controlStatus') {
+      setControlStatus(event.message)
     }
   }), [])
 

--- a/src/client/pages/ship/modules.js
+++ b/src/client/pages/ship/modules.js
@@ -6,6 +6,14 @@ import Panel from 'components/panel'
 import ShipModulesPanel from 'components/panels/ship/ship-modules-panel'
 import ShipModuleInspectorPanel from 'components/panels/ship/ship-module-inspector-panel'
 
+const SWITCH_COMMANDS = {
+  lights: 'ShipSpotLightToggle',
+  nightVision: 'NightVisionToggle',
+  cargoHatch: 'ToggleCargoScoop',
+  landingGear: 'LandingGearToggle',
+  hardpoints: 'DeployHardpointToggle'
+}
+
 export default function ShipStatusPage () {
   const { connected, active, ready } = useSocket()
   const [ship, setShip] = useState()
@@ -34,10 +42,11 @@ export default function ShipStatusPage () {
   }, [connected, ready])
 
   const toggleSwitch = async (switchName) => {
-    if (!controlStatus?.controls?.[switchName]?.key) return
+    const commandId = SWITCH_COMMANDS[switchName]
+    if (!controlStatus?.controls?.[commandId]?.key) return
 
     // Only toggle switch value if the local input backend accepted the command.
-    const switchToggled = await sendEvent('toggleSwitch', { switchName })
+    const switchToggled = await sendEvent('toggleSwitch', { switchName: commandId })
 
     if (switchToggled) {
       setToggleSwitches((previousSwitches) => ({

--- a/src/client/pages/ship/status.js
+++ b/src/client/pages/ship/status.js
@@ -11,6 +11,7 @@ export default function ShipStatusPage () {
   const [ship, setShip] = useState()
   const [selectedModule, setSelectedModule] = useState()
   const [cmdrStatus, setCmdrStatus] = useState()
+  const [controlStatus, setControlStatus] = useState()
 
   // Using state for toggle switches like this allow us to have the UI
   // respond immediately to the input from the user, even if it takes the game
@@ -29,19 +30,21 @@ export default function ShipStatusPage () {
     if (!connected) return
     setShip(await sendEvent('getShipStatus'))
     setCmdrStatus(await sendEvent('getCmdrStatus'))
+    setControlStatus(await sendEvent('getControlStatus'))
   }, [connected, ready])
 
   const toggleSwitch = async (switchName) => {
+    if (!controlStatus?.controls?.[switchName]?.key) return
 
-    /*
-    // Only toggle switch value if we think it was successful
+    // Only toggle switch value if the local input backend accepted the command.
     const switchToggled = await sendEvent('toggleSwitch', { switchName })
 
-    setToggleSwitches({
-      ...toggleSwitches,
-      [switchName]: switchToggled ? !toggleSwitches[switchName] : toggleSwitches[switchName]
-    })
-    */
+    if (switchToggled) {
+      setToggleSwitches((previousSwitches) => ({
+        ...previousSwitches,
+        [switchName]: !previousSwitches[switchName]
+      }))
+    }
   }
 
   useEffect(async () => {
@@ -66,6 +69,12 @@ export default function ShipStatusPage () {
     }
   }), [])
 
+  useEffect(() => eventListener('syncMessage', async (event) => {
+    if (event.name === 'controlStatus') {
+      setControlStatus(event.message)
+    }
+  }), [])
+
   return (
     <Layout connected={connected} active={active} ready={ready} className='ship-panel'>
       <Panel navigation={ShipPanelNavItems('Status')} scrollable>
@@ -74,6 +83,7 @@ export default function ShipStatusPage () {
           cmdrStatus={cmdrStatus}
           toggleSwitches={toggleSwitches}
           toggleSwitch={toggleSwitch}
+          controlStatus={controlStatus}
           selectedModule={selectedModule}
           setSelectedModule={setSelectedModule}
         />

--- a/src/client/pages/ship/status.js
+++ b/src/client/pages/ship/status.js
@@ -6,6 +6,14 @@ import Panel from 'components/panel'
 import ShipStatusPanel from 'components/panels/ship/ship-status-panel'
 import ShipModuleInspectorPanel from 'components/panels/ship/ship-module-inspector-panel'
 
+const SWITCH_COMMANDS = {
+  lights: 'ShipSpotLightToggle',
+  nightVision: 'NightVisionToggle',
+  cargoHatch: 'ToggleCargoScoop',
+  landingGear: 'LandingGearToggle',
+  hardpoints: 'DeployHardpointToggle'
+}
+
 export default function ShipStatusPage () {
   const { connected, active, ready } = useSocket()
   const [ship, setShip] = useState()
@@ -34,10 +42,11 @@ export default function ShipStatusPage () {
   }, [connected, ready])
 
   const toggleSwitch = async (switchName) => {
-    if (!controlStatus?.controls?.[switchName]?.key) return
+    const commandId = SWITCH_COMMANDS[switchName]
+    if (!controlStatus?.controls?.[commandId]?.key) return
 
     // Only toggle switch value if the local input backend accepted the command.
-    const switchToggled = await sendEvent('toggleSwitch', { switchName })
+    const switchToggled = await sendEvent('toggleSwitch', { switchName: commandId })
 
     if (switchToggled) {
       setToggleSwitches((previousSwitches) => ({

--- a/src/service/lib/controls/README.md
+++ b/src/service/lib/controls/README.md
@@ -1,0 +1,64 @@
+# Control layer
+
+The controls service connects remote UI actions to Elite Dangerous keyboard
+bindings. It is intentionally split into two parts:
+
+- `binding-resolver.js` reads the active Elite Dangerous `.binds` file and
+  exposes dashboard-safe controls by Elite binding name.
+- `input-backends/` contains the platform-specific code that sends keyboard
+  input to the game.
+
+The existing ship switches use the same path that a future configurable control
+panel can use:
+
+```text
+UI action
+-> Controls.tapControl(controlName)
+-> BindingResolver resolves controlName to a keyboard binding
+-> platform input backend sends the key
+```
+
+`controlName` should be the Elite binding name, for example:
+
+```text
+ShipSpotLightToggle
+NightVisionToggle
+ToggleCargoScoop
+LandingGearToggle
+DeployHardpointToggle
+```
+
+## Current platform support
+
+Linux is currently implemented through `xdotool` in
+`input-backends/linux-xdotool.js`.
+
+This requires:
+
+- `ICARUS_ENABLE_CONTROLS=true`
+- `xdotool`
+- an X11 session, or an environment where `xdotool` can send input to the game
+
+Other platforms intentionally use `input-backends/unsupported.js`.
+
+## Adding another backend
+
+Add a file under `input-backends/` that implements this interface:
+
+```js
+class SomeInputBackend {
+  async tapKey (key) {}
+  async keyDown (key) {}
+  async keyUp (key) {}
+}
+```
+
+Then register it in `input-backends/index.js` by checking `process.platform`.
+
+For Windows, the expected implementation would be a native input backend using
+`SendInput`. For Wayland, the backend should use a mechanism that is explicit
+about the compositor/security requirements rather than pretending `xdotool`
+works universally.
+
+The request handlers should not contain platform-specific input logic; they
+should keep calling the `Controls` service.

--- a/src/service/lib/controls/README.md
+++ b/src/service/lib/controls/README.md
@@ -4,7 +4,8 @@ The controls service connects remote UI actions to Elite Dangerous keyboard
 bindings. It is intentionally split into two parts:
 
 - `binding-resolver.js` reads the active Elite Dangerous `.binds` file and
-  exposes dashboard-safe controls by Elite binding name.
+  exposes dashboard-safe controls by Elite binding name and returns keyboard
+  bindings using Elite key names.
 - `input-backends/` contains the platform-specific code that sends keyboard
   input to the game.
 
@@ -15,7 +16,7 @@ panel can use:
 UI action
 -> Controls.tapControl(controlName)
 -> BindingResolver resolves controlName to a keyboard binding
--> platform input backend sends the key
+-> platform input backend translates and sends the key
 ```
 
 `controlName` should be the Elite binding name, for example:
@@ -47,11 +48,25 @@ Add a file under `input-backends/` that implements this interface:
 
 ```js
 class SomeInputBackend {
-  async tapKey (key) {}
-  async keyDown (key) {}
-  async keyUp (key) {}
+  async tapKey (binding) {}
+  async keyDown (binding) {}
+  async keyUp (binding) {}
 }
 ```
+
+`binding` is a platform-neutral object from the Elite `.binds` file:
+
+```js
+{
+  key: 'Numpad_1',
+  modifiers: ['LeftShift'],
+  display: 'LeftShift+Numpad_1'
+}
+```
+
+Backends are responsible for translating these Elite key names to their own
+input API. For example, the Linux backend translates `Numpad_1` to `KP_1` for
+`xdotool`.
 
 Then register it in `input-backends/index.js` by checking `process.platform`.
 

--- a/src/service/lib/controls/README.md
+++ b/src/service/lib/controls/README.md
@@ -48,9 +48,9 @@ Add a file under `input-backends/` that implements this interface:
 
 ```js
 class SomeInputBackend {
-  async tapKey (binding) {}
-  async keyDown (binding) {}
-  async keyUp (binding) {}
+  async tapBinding (binding) {}
+  async bindingDown (binding) {}
+  async bindingUp (binding) {}
 }
 ```
 

--- a/src/service/lib/controls/binding-resolver.js
+++ b/src/service/lib/controls/binding-resolver.js
@@ -1,0 +1,205 @@
+const os = require('os')
+const fs = require('fs')
+const path = require('path')
+const xml2js = require('xml2js')
+
+class BindingResolver {
+  constructor ({ logDir = global.LOG_DIR, bindingsDir = process.env.ICARUS_BINDINGS_DIR } = {}) {
+    this.logDir = logDir
+    this.bindingsDir = bindingsDir || inferBindingsDir(logDir) || defaultBindingsDir()
+  }
+
+  async resolveBindings (controlRegistry) {
+    const bindingsFile = this.findActiveBindingsFile()
+    if (!bindingsFile) {
+      return {
+        bindingsDir: this.bindingsDir,
+        bindingsFile: null,
+        controls: {}
+      }
+    }
+
+    const xml = fs.readFileSync(bindingsFile).toString()
+    const document = await xml2js.parseStringPromise(xml, {
+      explicitArray: false
+    })
+
+    const controls = {}
+    for (const [controlName, control] of Object.entries(controlRegistry)) {
+      controls[controlName] = resolveKeyboardBinding(document.Root?.[control.eliteBinding])
+    }
+
+    return {
+      bindingsDir: this.bindingsDir,
+      bindingsFile,
+      controls
+    }
+  }
+
+  findActiveBindingsFile () {
+    if (!this.bindingsDir || !fs.existsSync(this.bindingsDir)) return null
+
+    const presetNames = this.readStartPresetNames()
+    const bindFiles = fs.readdirSync(this.bindingsDir).filter((filename) => filename.endsWith('.binds'))
+
+    for (const presetName of presetNames) {
+      const matchingBindFiles = bindFiles
+        .filter((filename) => filename.startsWith(`${presetName}.`))
+        .sort(compareBindingFileVersions)
+        .reverse()
+
+      if (matchingBindFiles.length > 0) {
+        return path.join(this.bindingsDir, matchingBindFiles[0])
+      }
+    }
+
+    if (bindFiles.length === 1) return path.join(this.bindingsDir, bindFiles[0])
+
+    const customBindFiles = bindFiles
+      .filter((filename) => filename.startsWith('Custom.'))
+      .sort(compareBindingFileVersions)
+      .reverse()
+
+    return customBindFiles.length > 0 ? path.join(this.bindingsDir, customBindFiles[0]) : null
+  }
+
+  readStartPresetNames () {
+    if (!this.bindingsDir || !fs.existsSync(this.bindingsDir)) return []
+
+    return fs.readdirSync(this.bindingsDir)
+      .filter((filename) => filename.endsWith('.start'))
+      .flatMap((filename) => {
+        const contents = fs.readFileSync(path.join(this.bindingsDir, filename)).toString()
+        return contents.split(/\r?\n/)
+          .map((presetName) => presetName.trim())
+          .filter(Boolean)
+      })
+      .reverse()
+  }
+}
+
+function resolveKeyboardBinding (bindingNode) {
+  const bindingCandidates = [
+    getBindingElement(bindingNode, 'Primary'),
+    getBindingElement(bindingNode, 'Secondary')
+  ].filter(Boolean)
+
+  for (const bindingElement of bindingCandidates) {
+    if (bindingElement.$?.Device !== 'Keyboard') continue
+
+    const key = convertEliteKeyToXdotoolKey(bindingElement.$?.Key)
+    if (!key) continue
+
+    const modifier = convertEliteModifierToXdotoolKey(bindingElement.Modifier)
+    return modifier ? `${modifier}+${key}` : key
+  }
+
+  return null
+}
+
+function getBindingElement (bindingNode, elementName) {
+  const element = bindingNode?.[elementName]
+  return Array.isArray(element) ? element[0] : element
+}
+
+function convertEliteKeyToXdotoolKey (key) {
+  if (!key || !key.startsWith('Key_')) return null
+
+  const keyName = key.replace(/^Key_/, '')
+  if (keyName.length === 1) return keyName.toLowerCase()
+
+  const numpadKeys = {
+    Numpad_0: 'KP_0',
+    Numpad_1: 'KP_1',
+    Numpad_2: 'KP_2',
+    Numpad_3: 'KP_3',
+    Numpad_4: 'KP_4',
+    Numpad_5: 'KP_5',
+    Numpad_6: 'KP_6',
+    Numpad_7: 'KP_7',
+    Numpad_8: 'KP_8',
+    Numpad_9: 'KP_9',
+    Numpad_Add: 'KP_Add',
+    Numpad_Decimal: 'KP_Decimal',
+    Numpad_Divide: 'KP_Divide',
+    Numpad_Enter: 'KP_Enter',
+    Numpad_Multiply: 'KP_Multiply',
+    Numpad_Subtract: 'KP_Subtract'
+  }
+
+  const specialKeys = {
+    BackSlash: 'backslash',
+    BackSpace: 'BackSpace',
+    Comma: 'comma',
+    Delete: 'Delete',
+    DownArrow: 'Down',
+    End: 'End',
+    Enter: 'Return',
+    Equals: 'equal',
+    Escape: 'Escape',
+    ForwardSlash: 'slash',
+    Home: 'Home',
+    Insert: 'Insert',
+    LeftArrow: 'Left',
+    Minus: 'minus',
+    PageDown: 'Page_Down',
+    PageUp: 'Page_Up',
+    Period: 'period',
+    RightArrow: 'Right',
+    Space: 'space',
+    Tab: 'Tab',
+    UpArrow: 'Up'
+  }
+
+  if (numpadKeys[keyName]) return numpadKeys[keyName]
+  return specialKeys[keyName] || keyName
+}
+
+function convertEliteModifierToXdotoolKey (modifierElement) {
+  const modifier = Array.isArray(modifierElement) ? modifierElement[0] : modifierElement
+  if (modifier?.$?.Device !== 'Keyboard') return null
+
+  const key = modifier.$?.Key?.replace(/^Key_/, '')
+  const modifiers = {
+    LeftAlt: 'alt',
+    RightAlt: 'alt',
+    LeftControl: 'ctrl',
+    RightControl: 'ctrl',
+    LeftShift: 'shift',
+    RightShift: 'shift'
+  }
+
+  return modifiers[key] || null
+}
+
+function inferBindingsDir (logDir) {
+  if (!logDir) return null
+
+  const suffix = path.join('Saved Games', 'Frontier Developments', 'Elite Dangerous')
+  if (!logDir.endsWith(suffix)) return null
+
+  const profileDir = logDir.slice(0, -suffix.length)
+  return path.join(profileDir, 'AppData', 'Local', 'Frontier Developments', 'Elite Dangerous', 'Options', 'Bindings')
+}
+
+function defaultBindingsDir () {
+  return path.join(os.homedir(), 'AppData', 'Local', 'Frontier Developments', 'Elite Dangerous', 'Options', 'Bindings')
+}
+
+function compareBindingFileVersions (left, right) {
+  const leftVersion = extractBindingFileVersion(left)
+  const rightVersion = extractBindingFileVersion(right)
+
+  for (let index = 0; index < Math.max(leftVersion.length, rightVersion.length); index++) {
+    const diff = (leftVersion[index] || 0) - (rightVersion[index] || 0)
+    if (diff !== 0) return diff
+  }
+
+  return left.localeCompare(right)
+}
+
+function extractBindingFileVersion (filename) {
+  return filename.match(/\d+/g)?.map((numberPart) => Number(numberPart)) || []
+}
+
+module.exports = BindingResolver

--- a/src/service/lib/controls/binding-resolver.js
+++ b/src/service/lib/controls/binding-resolver.js
@@ -2,6 +2,7 @@ const os = require('os')
 const fs = require('fs')
 const path = require('path')
 const xml2js = require('xml2js')
+const { createDiscoveredControl, isDashboardControl } = require('./control-registry')
 
 class BindingResolver {
   constructor ({ logDir = global.LOG_DIR, bindingsDir = process.env.ICARUS_BINDINGS_DIR } = {}) {
@@ -9,13 +10,14 @@ class BindingResolver {
     this.bindingsDir = bindingsDir || inferBindingsDir(logDir) || defaultBindingsDir()
   }
 
-  async resolveBindings (controlRegistry) {
+  async resolveBindings () {
     const bindingsFile = this.findActiveBindingsFile()
     if (!bindingsFile) {
       return {
         bindingsDir: this.bindingsDir,
         bindingsFile: null,
-        controls: {}
+        controls: {},
+        registry: {}
       }
     }
 
@@ -24,15 +26,23 @@ class BindingResolver {
       explicitArray: false
     })
 
+    const registry = {}
+    for (const [name, bindingNode] of Object.entries(document.Root || {})) {
+      if (isDashboardControl(name, bindingNode)) {
+        registry[name] = createDiscoveredControl(name)
+      }
+    }
+
     const controls = {}
-    for (const [controlName, control] of Object.entries(controlRegistry)) {
+    for (const [controlName, control] of Object.entries(registry)) {
       controls[controlName] = resolveKeyboardBinding(document.Root?.[control.eliteBinding])
     }
 
     return {
       bindingsDir: this.bindingsDir,
       bindingsFile,
-      controls
+      controls,
+      registry
     }
   }
 

--- a/src/service/lib/controls/binding-resolver.js
+++ b/src/service/lib/controls/binding-resolver.js
@@ -97,11 +97,17 @@ function resolveKeyboardBinding (bindingNode) {
   for (const bindingElement of bindingCandidates) {
     if (bindingElement.$?.Device !== 'Keyboard') continue
 
-    const key = convertEliteKeyToXdotoolKey(bindingElement.$?.Key)
+    const key = stripEliteKeyPrefix(bindingElement.$?.Key)
     if (!key) continue
 
-    const modifier = convertEliteModifierToXdotoolKey(bindingElement.Modifier)
-    return modifier ? `${modifier}+${key}` : key
+    const modifier = parseEliteKeyboardModifier(bindingElement.Modifier)
+    const modifiers = modifier ? [modifier] : []
+
+    return {
+      key,
+      modifiers,
+      display: [...modifiers, key].join('+')
+    }
   }
 
   return null
@@ -112,74 +118,16 @@ function getBindingElement (bindingNode, elementName) {
   return Array.isArray(element) ? element[0] : element
 }
 
-function convertEliteKeyToXdotoolKey (key) {
+function stripEliteKeyPrefix (key) {
   if (!key || !key.startsWith('Key_')) return null
-
-  const keyName = key.replace(/^Key_/, '')
-  if (keyName.length === 1) return keyName.toLowerCase()
-
-  const numpadKeys = {
-    Numpad_0: 'KP_0',
-    Numpad_1: 'KP_1',
-    Numpad_2: 'KP_2',
-    Numpad_3: 'KP_3',
-    Numpad_4: 'KP_4',
-    Numpad_5: 'KP_5',
-    Numpad_6: 'KP_6',
-    Numpad_7: 'KP_7',
-    Numpad_8: 'KP_8',
-    Numpad_9: 'KP_9',
-    Numpad_Add: 'KP_Add',
-    Numpad_Decimal: 'KP_Decimal',
-    Numpad_Divide: 'KP_Divide',
-    Numpad_Enter: 'KP_Enter',
-    Numpad_Multiply: 'KP_Multiply',
-    Numpad_Subtract: 'KP_Subtract'
-  }
-
-  const specialKeys = {
-    BackSlash: 'backslash',
-    BackSpace: 'BackSpace',
-    Comma: 'comma',
-    Delete: 'Delete',
-    DownArrow: 'Down',
-    End: 'End',
-    Enter: 'Return',
-    Equals: 'equal',
-    Escape: 'Escape',
-    ForwardSlash: 'slash',
-    Home: 'Home',
-    Insert: 'Insert',
-    LeftArrow: 'Left',
-    Minus: 'minus',
-    PageDown: 'Page_Down',
-    PageUp: 'Page_Up',
-    Period: 'period',
-    RightArrow: 'Right',
-    Space: 'space',
-    Tab: 'Tab',
-    UpArrow: 'Up'
-  }
-
-  if (numpadKeys[keyName]) return numpadKeys[keyName]
-  return specialKeys[keyName] || keyName
+  return key.replace(/^Key_/, '')
 }
 
-function convertEliteModifierToXdotoolKey (modifierElement) {
+function parseEliteKeyboardModifier (modifierElement) {
   const modifier = Array.isArray(modifierElement) ? modifierElement[0] : modifierElement
   if (modifier?.$?.Device !== 'Keyboard') return null
 
-  const key = modifier.$?.Key?.replace(/^Key_/, '')
-  const modifiers = {
-    LeftAlt: 'alt',
-    RightAlt: 'alt',
-    LeftControl: 'ctrl',
-    RightControl: 'ctrl',
-    LeftShift: 'shift',
-    RightShift: 'shift'
-  }
-
-  return modifiers[key] || null
+  return stripEliteKeyPrefix(modifier.$?.Key)
 }
 
 function inferBindingsDir (logDir) {

--- a/src/service/lib/controls/control-registry.js
+++ b/src/service/lib/controls/control-registry.js
@@ -55,24 +55,11 @@ const CONTROL_METADATA = {
   }
 }
 
-// The bindings file also contains continuous movement, steering, and camera
+// The bindings file also contains analog axes, raw inputs, headlook, and camera
 // controls. They are intentionally excluded from dashboard action buttons.
 const STEERING_CONTROL_PATTERNS = [
   /Axis/,
   /Raw$/,
-  /Steer/,
-  /Thrust/,
-  /Throttle/,
-  /DriveSpeed/,
-  /ForwardButton$/,
-  /BackwardButton$/,
-  /LeftButton$/,
-  /RightButton$/,
-  /UpButton$/,
-  /DownButton$/,
-  /Pitch/,
-  /Yaw/,
-  /Roll/,
   /HeadLook/,
   /Headlook/i,
   /Camera/,

--- a/src/service/lib/controls/control-registry.js
+++ b/src/service/lib/controls/control-registry.js
@@ -1,0 +1,28 @@
+// ICARUS names stay stable even if the underlying Elite binding or input
+// backend changes.
+const CONTROL_REGISTRY = {
+  lights: {
+    eliteBinding: 'ShipSpotLightToggle',
+    keyEnv: 'ICARUS_CONTROL_LIGHTS_KEY'
+  },
+  nightVision: {
+    eliteBinding: 'NightVisionToggle',
+    keyEnv: 'ICARUS_CONTROL_NIGHT_VISION_KEY'
+  },
+  landingGear: {
+    eliteBinding: 'LandingGearToggle',
+    keyEnv: 'ICARUS_CONTROL_LANDING_GEAR_KEY'
+  },
+  cargoHatch: {
+    eliteBinding: 'ToggleCargoScoop',
+    keyEnv: 'ICARUS_CONTROL_CARGO_HATCH_KEY'
+  },
+  hardpoints: {
+    eliteBinding: 'DeployHardpointToggle',
+    keyEnv: 'ICARUS_CONTROL_HARDPOINTS_KEY'
+  }
+}
+
+module.exports = {
+  CONTROL_REGISTRY
+}

--- a/src/service/lib/controls/control-registry.js
+++ b/src/service/lib/controls/control-registry.js
@@ -1,28 +1,195 @@
-// ICARUS names stay stable even if the underlying Elite binding or input
-// backend changes.
-const CONTROL_REGISTRY = {
-  lights: {
-    eliteBinding: 'ShipSpotLightToggle',
-    keyEnv: 'ICARUS_CONTROL_LIGHTS_KEY'
+// Elite binding names are the stable command IDs. ICARUS only overlays UI and
+// safety metadata where automatic discovery cannot infer enough.
+const CONTROL_METADATA = {
+  ShipSpotLightToggle: {
+    label: 'Ship Lights',
+    stateFlag: 'lightsOn'
   },
-  nightVision: {
-    eliteBinding: 'NightVisionToggle',
-    keyEnv: 'ICARUS_CONTROL_NIGHT_VISION_KEY'
+  NightVisionToggle: {
+    label: 'Night Vision',
+    stateFlag: 'nightVision'
   },
-  landingGear: {
-    eliteBinding: 'LandingGearToggle',
-    keyEnv: 'ICARUS_CONTROL_LANDING_GEAR_KEY'
+  ToggleCargoScoop: {
+    label: 'Cargo Hatch',
+    stateFlag: 'cargoScoopDeployed'
   },
-  cargoHatch: {
-    eliteBinding: 'ToggleCargoScoop',
-    keyEnv: 'ICARUS_CONTROL_CARGO_HATCH_KEY'
+  LandingGearToggle: {
+    label: 'Landing Gear',
+    stateFlag: 'landingGearDown'
   },
-  hardpoints: {
-    eliteBinding: 'DeployHardpointToggle',
-    keyEnv: 'ICARUS_CONTROL_HARDPOINTS_KEY'
+  DeployHardpointToggle: {
+    label: 'Hardpoints',
+    stateFlag: 'hardpointsDeployed'
+  },
+  GalaxyMapOpen: {
+    label: 'Galaxy Map'
+  },
+  SystemMapOpen: {
+    label: 'System Map'
+  },
+  TargetNextRouteSystem: {
+    label: 'Next Route System'
+  },
+  CycleNextTarget: {
+    label: 'Next Target'
+  },
+  CyclePreviousTarget: {
+    label: 'Previous Target'
+  },
+  FireChaffLauncher: {
+    label: 'Chaff'
+  },
+  RecallDismissShip: {
+    label: 'Recall / Dismiss Ship'
+  },
+  EjectAllCargo: {
+    requiresConfirmation: true
+  },
+  ToggleDriveAssist: {
+    label: 'Drive Assist',
+    context: 'srv'
+  },
+  HumanoidToggleNightVision: {
+    label: 'Flashlight',
+    context: 'on-foot'
+  }
+}
+
+// The bindings file also contains continuous movement, steering, and camera
+// controls. They are intentionally excluded from dashboard action buttons.
+const STEERING_CONTROL_PATTERNS = [
+  /Axis/,
+  /Raw$/,
+  /Steer/,
+  /Thrust/,
+  /Throttle/,
+  /DriveSpeed/,
+  /ForwardButton$/,
+  /BackwardButton$/,
+  /LeftButton$/,
+  /RightButton$/,
+  /UpButton$/,
+  /DownButton$/,
+  /Pitch/,
+  /Yaw/,
+  /Roll/,
+  /HeadLook/,
+  /Headlook/i,
+  /Camera/,
+  /^Cam/,
+  /^EnableCamera/,
+  /^FixCamera/,
+  /^FreeCam/,
+  /^MoveFreeCam/,
+  /^MovePlacementCam/,
+  /^PhotoCamera/,
+  /^PlacementCam/,
+  /^PitchCamera/,
+  /^PitchPlacementCamera/,
+  /^QuitCamera/,
+  /^RollCamera/,
+  /^StoreCam/,
+  /^StorePitchCamera/,
+  /^StoreYawCamera/,
+  /^ThrottleRangeFreeCam/,
+  /^ToggleFreeCam/,
+  /^ToggleReverseThrottleInputFreeCam/,
+  /^VanityCamera/,
+  /^YawCamera/,
+  /^YawPlacementCamera/,
+  /^CommanderCreator_Rotation/,
+  /^SAAThirdPerson/,
+  /^ExplorationFSSCamera/,
+  /^ExplorationFSSRadioTuning/
+]
+
+const MISC_CONTROL_PATTERNS = [
+  /^ToggleAdvanceMode$/,
+  /^ToggleButtonUpInput$/,
+  /^DisableRotationCorrectToggle$/,
+  /^FocusCommsPanel$/,
+  /^FocusLeftPanel$/,
+  /^FocusRadarPanel$/,
+  /^FocusRightPanel$/,
+  /^HMDReset$/,
+  /^OpenCodexGoToDiscovery$/,
+  /^QuickCommsPanel$/,
+  /^ToggleRotationLock$/,
+  /^ChangeConstructionOption$/,
+  /^DecreaseSpeedButtonMax$/,
+  /^FStop/,
+  /^GalaxyMapHome$/,
+  /^IncreaseSpeedButtonMax$/,
+  /^MicrophoneMute$/,
+  /^MouseReset$/,
+  /^OpenOrders$/,
+  /^BlockMouseDecay$/,
+  /^ForwardKey$/,
+  /^BackwardKey$/,
+  /^SetSpeed/,
+  /PrimaryFire/,
+  /SecondaryFire/,
+  /^WeaponColour/,
+  /^EngineColour/,
+  /^ShowPGScoreSummaryInput$/,
+  /^Pause$/,
+  /^FriendsMenu$/,
+  /^TriggerColonisationModule$/,
+  /^UIFocus/,
+  /^UI_(Up|Down|Left|Right|Select|Back|Toggle)$/,
+  /^UseAlternateFlightValues/,
+  /^CycleNextPanel$/,
+  /^CyclePreviousPanel$/,
+  /^CycleNextPage$/,
+  /^CyclePreviousPage$/,
+  /^GalnetAudio_/,
+  /^Exploration/
+]
+
+function isDashboardControl (name, bindingNode) {
+  if (!name || name === '$') return false
+  if (!bindingNode || typeof bindingNode !== 'object') return false
+  if (STEERING_CONTROL_PATTERNS.some(pattern => pattern.test(name))) return false
+  return Boolean(bindingNode.Primary || bindingNode.Secondary)
+}
+
+function inferControlContext (name) {
+  if (/Emote/.test(name)) return 'emote'
+  if (/^MultiCrew|^Order|^TargetWingman|^WingNavLock/.test(name)) return 'multicrew'
+  if (MISC_CONTROL_PATTERNS.some(pattern => pattern.test(name))) return 'misc'
+  if (/Humanoid|Store|Settlement|CommanderCreator/.test(name)) return 'on-foot'
+  if (/Buggy|Vehicle|_Buggy$/.test(name)) return 'srv'
+  return 'ship'
+}
+
+function formatControlLabel (name) {
+  return name
+    .replace(/_Buggy$/, '')
+    .replace(/^Humanoid/, '')
+    .replace(/^Vehicle/, 'SRV ')
+    .replace(/^Toggle/, '')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\bButton\b/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function createDiscoveredControl (name) {
+  const metadata = CONTROL_METADATA[name] || {}
+
+  return {
+    label: metadata.label || formatControlLabel(name),
+    context: metadata.context || inferControlContext(name),
+    eliteBinding: name,
+    inputMode: metadata.inputMode || 'tap',
+    stateFlag: metadata.stateFlag || null,
+    requiresConfirmation: metadata.requiresConfirmation === true
   }
 }
 
 module.exports = {
-  CONTROL_REGISTRY
+  CONTROL_METADATA,
+  createDiscoveredControl,
+  isDashboardControl
 }

--- a/src/service/lib/controls/index.js
+++ b/src/service/lib/controls/index.js
@@ -1,4 +1,3 @@
-const { CONTROL_REGISTRY } = require('./control-registry')
 const BindingResolver = require('./binding-resolver')
 const { createInputBackend } = require('./input-backends')
 
@@ -11,6 +10,7 @@ class Controls {
     this.bindingResolver = bindingResolver
     this.inputBackend = inputBackend
     this.enabled = enabled
+    this.controlRegistry = {}
     this.bindingCache = {
       bindingsDir: bindingResolver.bindingsDir,
       bindingsFile: null,
@@ -21,36 +21,72 @@ class Controls {
   }
 
   async toggleSwitch ({ switchName }) {
+    return this.tapControl({ controlName: switchName })
+  }
+
+  async tapControl ({ controlName }) {
     if (!this.enabled) {
-      console.warn('CONTROL_REJECTED_DISABLED', switchName)
+      console.warn('CONTROL_REJECTED_DISABLED', controlName)
       return false
     }
 
-    const control = CONTROL_REGISTRY[switchName]
+    const control = this.controlRegistry[controlName]
     if (!control) {
-      console.warn('CONTROL_REJECTED_UNSUPPORTED_SWITCH', switchName)
+      console.warn('CONTROL_REJECTED_UNSUPPORTED_CONTROL', controlName)
       return false
     }
 
-    const key = this.bindingCache.controls[switchName] || process.env[control.keyEnv]
+    const key = this.bindingCache.controls[controlName]
     if (!key) {
-      console.warn('CONTROL_REJECTED_MISSING_KEY', switchName, control.keyEnv)
+      console.warn('CONTROL_REJECTED_MISSING_KEY', controlName)
       return false
     }
 
     try {
-      await this.inputBackend.sendKey(key)
-      console.log('CONTROL_SENT', switchName, key, control.eliteBinding)
+      await this.inputBackend.tapKey(key)
+      console.log('CONTROL_SENT', controlName, key, control.eliteBinding)
       return true
     } catch (e) {
-      console.error('ERROR_SENDING_KEY', switchName, e.toString())
+      console.error('ERROR_SENDING_KEY', controlName, e.toString())
+      return false
+    }
+  }
+
+  async startControl ({ controlName }) {
+    return this.sendControlKey('down', controlName)
+  }
+
+  async stopControl ({ controlName }) {
+    return this.sendControlKey('up', controlName)
+  }
+
+  async sendControlKey (direction, controlName) {
+    if (!this.enabled) {
+      console.warn('CONTROL_REJECTED_DISABLED', controlName)
+      return false
+    }
+
+    const control = this.controlRegistry[controlName]
+    const key = control && this.bindingCache.controls[controlName]
+    if (!control || !key) {
+      console.warn('CONTROL_REJECTED_MISSING_KEY', controlName)
+      return false
+    }
+
+    try {
+      if (direction === 'down') await this.inputBackend.keyDown(key)
+      else await this.inputBackend.keyUp(key)
+      return true
+    } catch (e) {
+      console.error('ERROR_SENDING_KEY', direction, controlName, e.toString())
       return false
     }
   }
 
   async refreshBindings () {
     try {
-      this.bindingCache = await this.bindingResolver.resolveBindings(CONTROL_REGISTRY)
+      this.bindingCache = await this.bindingResolver.resolveBindings()
+      this.controlRegistry = this.bindingCache.registry || {}
       console.log('CONTROL_BINDINGS_REFRESHED', this.bindingCache.bindingsFile || 'no bindings file')
     } catch (e) {
       console.error('ERROR_REFRESHING_CONTROL_BINDINGS', e.toString())
@@ -62,11 +98,17 @@ class Controls {
   getControlStatus () {
     const controls = {}
 
-    for (const [controlName, control] of Object.entries(CONTROL_REGISTRY)) {
+    for (const [controlName, control] of Object.entries(this.controlRegistry)) {
       controls[controlName] = {
+        id: controlName,
+        label: control.label || controlName,
+        context: control.context || 'ship',
         eliteBinding: control.eliteBinding,
-        key: this.bindingCache.controls[controlName] || process.env[control.keyEnv] || null,
-        source: this.bindingCache.controls[controlName] ? 'bindings' : process.env[control.keyEnv] ? 'env' : null
+        inputMode: control.inputMode || 'tap',
+        stateFlag: control.stateFlag || null,
+        requiresConfirmation: control.requiresConfirmation === true,
+        key: this.bindingCache.controls[controlName] || null,
+        source: this.bindingCache.controls[controlName] ? 'bindings' : null
       }
     }
 

--- a/src/service/lib/controls/index.js
+++ b/src/service/lib/controls/index.js
@@ -36,15 +36,15 @@ class Controls {
       return false
     }
 
-    const key = this.bindingCache.controls[controlName]
-    if (!key) {
+    const binding = this.bindingCache.controls[controlName]
+    if (!binding) {
       console.warn('CONTROL_REJECTED_MISSING_KEY', controlName)
       return false
     }
 
     try {
-      await this.inputBackend.tapKey(key)
-      console.log('CONTROL_SENT', controlName, key, control.eliteBinding)
+      await this.inputBackend.tapKey(binding)
+      console.log('CONTROL_SENT', controlName, binding.display, control.eliteBinding)
       return true
     } catch (e) {
       console.error('ERROR_SENDING_KEY', controlName, e.toString())
@@ -67,15 +67,15 @@ class Controls {
     }
 
     const control = this.controlRegistry[controlName]
-    const key = control && this.bindingCache.controls[controlName]
-    if (!control || !key) {
+    const binding = control && this.bindingCache.controls[controlName]
+    if (!control || !binding) {
       console.warn('CONTROL_REJECTED_MISSING_KEY', controlName)
       return false
     }
 
     try {
-      if (direction === 'down') await this.inputBackend.keyDown(key)
-      else await this.inputBackend.keyUp(key)
+      if (direction === 'down') await this.inputBackend.keyDown(binding)
+      else await this.inputBackend.keyUp(binding)
       return true
     } catch (e) {
       console.error('ERROR_SENDING_KEY', direction, controlName, e.toString())
@@ -99,6 +99,7 @@ class Controls {
     const controls = {}
 
     for (const [controlName, control] of Object.entries(this.controlRegistry)) {
+      const binding = this.bindingCache.controls[controlName]
       controls[controlName] = {
         id: controlName,
         label: control.label || controlName,
@@ -107,8 +108,9 @@ class Controls {
         inputMode: control.inputMode || 'tap',
         stateFlag: control.stateFlag || null,
         requiresConfirmation: control.requiresConfirmation === true,
-        key: this.bindingCache.controls[controlName] || null,
-        source: this.bindingCache.controls[controlName] ? 'bindings' : null
+        key: binding?.display || null,
+        binding: binding || null,
+        source: binding ? 'bindings' : null
       }
     }
 

--- a/src/service/lib/controls/index.js
+++ b/src/service/lib/controls/index.js
@@ -43,7 +43,7 @@ class Controls {
     }
 
     try {
-      await this.inputBackend.tapKey(binding)
+      await this.inputBackend.tapBinding(binding)
       console.log('CONTROL_SENT', controlName, binding.display, control.eliteBinding)
       return true
     } catch (e) {
@@ -74,8 +74,8 @@ class Controls {
     }
 
     try {
-      if (direction === 'down') await this.inputBackend.keyDown(binding)
-      else await this.inputBackend.keyUp(binding)
+      if (direction === 'down') await this.inputBackend.bindingDown(binding)
+      else await this.inputBackend.bindingUp(binding)
       return true
     } catch (e) {
       console.error('ERROR_SENDING_KEY', direction, controlName, e.toString())
@@ -109,6 +109,7 @@ class Controls {
         stateFlag: control.stateFlag || null,
         requiresConfirmation: control.requiresConfirmation === true,
         key: binding?.display || null,
+        keyDisplay: binding?.display || null,
         binding: binding || null,
         source: binding ? 'bindings' : null
       }

--- a/src/service/lib/controls/index.js
+++ b/src/service/lib/controls/index.js
@@ -1,0 +1,83 @@
+const { CONTROL_REGISTRY } = require('./control-registry')
+const BindingResolver = require('./binding-resolver')
+const { createInputBackend } = require('./input-backends')
+
+class Controls {
+  constructor ({
+    bindingResolver = new BindingResolver(),
+    inputBackend = createInputBackend(),
+    enabled = process.env.ICARUS_ENABLE_CONTROLS === 'true'
+  } = {}) {
+    this.bindingResolver = bindingResolver
+    this.inputBackend = inputBackend
+    this.enabled = enabled
+    this.bindingCache = {
+      bindingsDir: bindingResolver.bindingsDir,
+      bindingsFile: null,
+      controls: {}
+    }
+
+    this.refreshBindings()
+  }
+
+  async toggleSwitch ({ switchName }) {
+    if (!this.enabled) {
+      console.warn('CONTROL_REJECTED_DISABLED', switchName)
+      return false
+    }
+
+    const control = CONTROL_REGISTRY[switchName]
+    if (!control) {
+      console.warn('CONTROL_REJECTED_UNSUPPORTED_SWITCH', switchName)
+      return false
+    }
+
+    const key = this.bindingCache.controls[switchName] || process.env[control.keyEnv]
+    if (!key) {
+      console.warn('CONTROL_REJECTED_MISSING_KEY', switchName, control.keyEnv)
+      return false
+    }
+
+    try {
+      await this.inputBackend.sendKey(key)
+      console.log('CONTROL_SENT', switchName, key, control.eliteBinding)
+      return true
+    } catch (e) {
+      console.error('ERROR_SENDING_KEY', switchName, e.toString())
+      return false
+    }
+  }
+
+  async refreshBindings () {
+    try {
+      this.bindingCache = await this.bindingResolver.resolveBindings(CONTROL_REGISTRY)
+      console.log('CONTROL_BINDINGS_REFRESHED', this.bindingCache.bindingsFile || 'no bindings file')
+    } catch (e) {
+      console.error('ERROR_REFRESHING_CONTROL_BINDINGS', e.toString())
+    }
+
+    return this.getControlStatus()
+  }
+
+  getControlStatus () {
+    const controls = {}
+
+    for (const [controlName, control] of Object.entries(CONTROL_REGISTRY)) {
+      controls[controlName] = {
+        eliteBinding: control.eliteBinding,
+        key: this.bindingCache.controls[controlName] || process.env[control.keyEnv] || null,
+        source: this.bindingCache.controls[controlName] ? 'bindings' : process.env[control.keyEnv] ? 'env' : null
+      }
+    }
+
+    return {
+      enabled: this.enabled,
+      platform: process.platform,
+      bindingsDir: this.bindingCache.bindingsDir,
+      bindingsFile: this.bindingCache.bindingsFile,
+      controls
+    }
+  }
+}
+
+module.exports = Controls

--- a/src/service/lib/controls/input-backends/index.js
+++ b/src/service/lib/controls/input-backends/index.js
@@ -1,0 +1,17 @@
+const LinuxXdotoolInputBackend = require('./linux-xdotool')
+const UnsupportedInputBackend = require('./unsupported')
+
+function createInputBackend () {
+  switch (process.platform) {
+    case 'linux':
+      return new LinuxXdotoolInputBackend()
+    // Windows should get a native SendInput backend here instead of shelling
+    // out from the request handler.
+    default:
+      return new UnsupportedInputBackend()
+  }
+}
+
+module.exports = {
+  createInputBackend
+}

--- a/src/service/lib/controls/input-backends/linux-xdotool.js
+++ b/src/service/lib/controls/input-backends/linux-xdotool.js
@@ -1,15 +1,29 @@
 const { execFile } = require('child_process')
 
 class LinuxXdotoolInputBackend {
-  async sendKey (key) {
-    const xdotoolKey = normalizeXdotoolKey(key)
+  async tapKey (key) {
+    await this.keyDown(key)
+    await this.keyUp(key)
+    return true
+  }
 
-    return new Promise((resolve, reject) => {
-      execFile('xdotool', ['key', '--clearmodifiers', xdotoolKey], (error) => {
-        if (error) reject(error)
-        else resolve(true)
-      })
-    })
+  async keyDown (key) {
+    return this.sendKeyCommand('keydown', key)
+  }
+
+  async keyUp (key) {
+    return this.sendKeyCommand('keyup', key)
+  }
+
+  async sendKeyCommand (command, key) {
+    const keyParts = normalizeXdotoolKey(key)
+
+    // Send modifiers before the main key and release them in reverse order.
+    const orderedKeys = command === 'keyup' ? [...keyParts].reverse() : keyParts
+    for (const keyPart of orderedKeys) {
+      await runXdotool(command, keyPart)
+    }
+    return true
   }
 }
 
@@ -23,7 +37,16 @@ function normalizeXdotoolKey (key) {
     throw new Error(`Unsafe key name: ${normalizedKey}`)
   }
 
-  return keyParts.join('+')
+  return keyParts
+}
+
+function runXdotool (command, key) {
+  return new Promise((resolve, reject) => {
+    execFile('xdotool', [command, key], (error) => {
+      if (error) reject(error)
+      else resolve(true)
+    })
+  })
 }
 
 module.exports = LinuxXdotoolInputBackend

--- a/src/service/lib/controls/input-backends/linux-xdotool.js
+++ b/src/service/lib/controls/input-backends/linux-xdotool.js
@@ -1,22 +1,22 @@
 const { execFile } = require('child_process')
 
 class LinuxXdotoolInputBackend {
-  async tapKey (key) {
-    await this.keyDown(key)
-    await this.keyUp(key)
+  async tapKey (binding) {
+    await this.keyDown(binding)
+    await this.keyUp(binding)
     return true
   }
 
-  async keyDown (key) {
-    return this.sendKeyCommand('keydown', key)
+  async keyDown (binding) {
+    return this.sendKeyCommand('keydown', binding)
   }
 
-  async keyUp (key) {
-    return this.sendKeyCommand('keyup', key)
+  async keyUp (binding) {
+    return this.sendKeyCommand('keyup', binding)
   }
 
-  async sendKeyCommand (command, key) {
-    const keyParts = normalizeXdotoolKey(key)
+  async sendKeyCommand (command, binding) {
+    const keyParts = normalizeXdotoolBinding(binding)
 
     // Send modifiers before the main key and release them in reverse order.
     const orderedKeys = command === 'keyup' ? [...keyParts].reverse() : keyParts
@@ -27,17 +27,84 @@ class LinuxXdotoolInputBackend {
   }
 }
 
-function normalizeXdotoolKey (key) {
-  const normalizedKey = `${key}`.trim()
-  const keyParts = normalizedKey.split('+').map((keyPart) => keyPart.trim()).filter(Boolean)
+function normalizeXdotoolBinding (binding) {
+  if (typeof binding === 'string') {
+    return validateXdotoolKeys(binding.split('+').map((keyPart) => keyPart.trim()).filter(Boolean), binding)
+  }
 
+  const keyParts = [
+    ...(binding?.modifiers || []).map(convertEliteKeyToXdotoolKey),
+    convertEliteKeyToXdotoolKey(binding?.key)
+  ].filter(Boolean)
+
+  return validateXdotoolKeys(keyParts, binding?.display || binding?.key)
+}
+
+function validateXdotoolKeys (keyParts, label) {
   if (keyParts.length === 0) throw new Error('No key configured')
-  if (keyParts.length > 4) throw new Error(`Unsupported key combination: ${normalizedKey}`)
+  if (keyParts.length > 4) throw new Error(`Unsupported key combination: ${label}`)
   if (keyParts.some((keyPart) => !/^[a-z0-9_]+$/i.test(keyPart))) {
-    throw new Error(`Unsafe key name: ${normalizedKey}`)
+    throw new Error(`Unsafe key name: ${label}`)
   }
 
   return keyParts
+}
+
+function convertEliteKeyToXdotoolKey (key) {
+  if (!key) return null
+  if (key.length === 1) return key.toLowerCase()
+
+  const numpadKeys = {
+    Numpad_0: 'KP_0',
+    Numpad_1: 'KP_1',
+    Numpad_2: 'KP_2',
+    Numpad_3: 'KP_3',
+    Numpad_4: 'KP_4',
+    Numpad_5: 'KP_5',
+    Numpad_6: 'KP_6',
+    Numpad_7: 'KP_7',
+    Numpad_8: 'KP_8',
+    Numpad_9: 'KP_9',
+    Numpad_Add: 'KP_Add',
+    Numpad_Decimal: 'KP_Decimal',
+    Numpad_Divide: 'KP_Divide',
+    Numpad_Enter: 'KP_Enter',
+    Numpad_Multiply: 'KP_Multiply',
+    Numpad_Subtract: 'KP_Subtract'
+  }
+
+  const specialKeys = {
+    BackSlash: 'backslash',
+    BackSpace: 'BackSpace',
+    Comma: 'comma',
+    Delete: 'Delete',
+    DownArrow: 'Down',
+    End: 'End',
+    Enter: 'Return',
+    Equals: 'equal',
+    Escape: 'Escape',
+    ForwardSlash: 'slash',
+    Home: 'Home',
+    Insert: 'Insert',
+    LeftAlt: 'alt',
+    LeftArrow: 'Left',
+    LeftControl: 'ctrl',
+    LeftShift: 'shift',
+    Minus: 'minus',
+    PageDown: 'Page_Down',
+    PageUp: 'Page_Up',
+    Period: 'period',
+    RightAlt: 'alt',
+    RightArrow: 'Right',
+    RightControl: 'ctrl',
+    RightShift: 'shift',
+    Space: 'space',
+    Tab: 'Tab',
+    UpArrow: 'Up'
+  }
+
+  if (numpadKeys[key]) return numpadKeys[key]
+  return specialKeys[key] || key
 }
 
 function runXdotool (command, key) {

--- a/src/service/lib/controls/input-backends/linux-xdotool.js
+++ b/src/service/lib/controls/input-backends/linux-xdotool.js
@@ -1,17 +1,17 @@
 const { execFile } = require('child_process')
 
 class LinuxXdotoolInputBackend {
-  async tapKey (binding) {
-    await this.keyDown(binding)
-    await this.keyUp(binding)
+  async tapBinding (binding) {
+    await this.bindingDown(binding)
+    await this.bindingUp(binding)
     return true
   }
 
-  async keyDown (binding) {
+  async bindingDown (binding) {
     return this.sendKeyCommand('keydown', binding)
   }
 
-  async keyUp (binding) {
+  async bindingUp (binding) {
     return this.sendKeyCommand('keyup', binding)
   }
 
@@ -28,10 +28,6 @@ class LinuxXdotoolInputBackend {
 }
 
 function normalizeXdotoolBinding (binding) {
-  if (typeof binding === 'string') {
-    return validateXdotoolKeys(binding.split('+').map((keyPart) => keyPart.trim()).filter(Boolean), binding)
-  }
-
   const keyParts = [
     ...(binding?.modifiers || []).map(convertEliteKeyToXdotoolKey),
     convertEliteKeyToXdotoolKey(binding?.key)

--- a/src/service/lib/controls/input-backends/linux-xdotool.js
+++ b/src/service/lib/controls/input-backends/linux-xdotool.js
@@ -1,0 +1,29 @@
+const { execFile } = require('child_process')
+
+class LinuxXdotoolInputBackend {
+  async sendKey (key) {
+    const xdotoolKey = normalizeXdotoolKey(key)
+
+    return new Promise((resolve, reject) => {
+      execFile('xdotool', ['key', '--clearmodifiers', xdotoolKey], (error) => {
+        if (error) reject(error)
+        else resolve(true)
+      })
+    })
+  }
+}
+
+function normalizeXdotoolKey (key) {
+  const normalizedKey = `${key}`.trim()
+  const keyParts = normalizedKey.split('+').map((keyPart) => keyPart.trim()).filter(Boolean)
+
+  if (keyParts.length === 0) throw new Error('No key configured')
+  if (keyParts.length > 4) throw new Error(`Unsupported key combination: ${normalizedKey}`)
+  if (keyParts.some((keyPart) => !/^[a-z0-9_]+$/i.test(keyPart))) {
+    throw new Error(`Unsafe key name: ${normalizedKey}`)
+  }
+
+  return keyParts.join('+')
+}
+
+module.exports = LinuxXdotoolInputBackend

--- a/src/service/lib/controls/input-backends/unsupported.js
+++ b/src/service/lib/controls/input-backends/unsupported.js
@@ -1,5 +1,13 @@
 class UnsupportedInputBackend {
-  async sendKey () {
+  async tapKey () {
+    throw new Error(`No input backend implemented for ${process.platform}`)
+  }
+
+  async keyDown () {
+    throw new Error(`No input backend implemented for ${process.platform}`)
+  }
+
+  async keyUp () {
     throw new Error(`No input backend implemented for ${process.platform}`)
   }
 }

--- a/src/service/lib/controls/input-backends/unsupported.js
+++ b/src/service/lib/controls/input-backends/unsupported.js
@@ -1,0 +1,7 @@
+class UnsupportedInputBackend {
+  async sendKey () {
+    throw new Error(`No input backend implemented for ${process.platform}`)
+  }
+}
+
+module.exports = UnsupportedInputBackend

--- a/src/service/lib/controls/input-backends/unsupported.js
+++ b/src/service/lib/controls/input-backends/unsupported.js
@@ -1,13 +1,13 @@
 class UnsupportedInputBackend {
-  async tapKey () {
+  async tapBinding () {
     throw new Error(`No input backend implemented for ${process.platform}`)
   }
 
-  async keyDown () {
+  async bindingDown () {
     throw new Error(`No input backend implemented for ${process.platform}`)
   }
 
-  async keyUp () {
+  async bindingUp () {
     throw new Error(`No input backend implemented for ${process.platform}`)
   }
 }

--- a/src/service/lib/event-handlers.js
+++ b/src/service/lib/event-handlers.js
@@ -8,23 +8,6 @@ const { UNKNOWN_VALUE } = require('../../shared/consts')
 
 const { BROADCAST_EVENT: broadcastEvent } = global
 
-// const TARGET_WINDOW_TITLE = 'Elite - Dangerous (CLIENT)'
-const KEYBINDS_DIR = path.join(os.homedir(), 'AppData', 'Local', 'Frontier Developments', 'Elite Dangerous', 'Options', 'Bindings')
-
-// Prefer Keybinds v4 file
-// TODO Check what version of game player has active
-const KEYBINDS_FILE_V3 = path.join(KEYBINDS_DIR, 'Custom.3.0.binds') // Horizons
-const KEYBINDS_FILE_V4 = path.join(KEYBINDS_DIR, 'Custom.4.0.binds') // Odyssey
-
-// Map ICARUS Terminal names to in-game keybind names
-const KEYBINDS_MAP = {
-  lights: 'ShipSpotLightToggle',
-  nightVision: 'NightVisionToggle',
-  landingGear: 'LandingGearToggle',
-  cargoHatch: 'ToggleCargoScoop',
-  hardpoints: 'DeployHardpointToggle'
-}
-
 // FIXME Refactor Preferences handling into a singleton
 const PREFERENCES_DIR = path.join(os.homedir(), 'AppData', 'Local', 'ICARUS Terminal')
 const PREFERENCES_FILE = path.join(PREFERENCES_DIR, 'Preferences.json')
@@ -38,6 +21,7 @@ const Inventory = require('./event-handlers/inventory')
 const CmdrStatus = require('./event-handlers/cmdr-status')
 const NavRoute = require('./event-handlers/nav-route')
 const TextToSpeech = require('./event-handlers/text-to-speech')
+const Controls = require('./controls')
 
 class EventHandlers {
   constructor ({ eliteLog, eliteJson }) {
@@ -55,6 +39,7 @@ class EventHandlers {
     this.blueprints = new Blueprints({ engineers: this.engineers, materials: this.materials, shipStatus: this.shipStatus })
     this.navRoute = new NavRoute({ eliteLog, eliteJson, system: this.system })
     this.textToSpeech = new TextToSpeech({ eliteLog, eliteJson, cmdrStatus: this.cmdrStatus, shipStatus: this.shipStatus })
+    this.controls = new Controls()
 
     return this
   }
@@ -94,6 +79,12 @@ class EventHandlers {
         getCmdrStatus: (args) => this.cmdrStatus.getCmdrStatus(args),
         getBlueprints: (args) => this.blueprints.getBlueprints(args),
         getNavRoute: (args) => this.navRoute.getNavRoute(args),
+        getControlStatus: () => this.controls.getControlStatus(),
+        refreshBindings: async () => {
+          const controlStatus = await this.controls.refreshBindings()
+          broadcastEvent('syncMessage', { name: 'controlStatus', message: controlStatus })
+          return controlStatus
+        },
         getPreferences: () => {
           return fs.existsSync(PREFERENCES_FILE) ? JSON.parse(fs.readFileSync(PREFERENCES_FILE)) : {}
         },
@@ -115,7 +106,7 @@ class EventHandlers {
         //     return null
         //   }
         // },
-        testMessage: ({name, message}) => {
+        testMessage: ({ name, message }) => {
           // Method to simulate messages, intended for developers
           if (name !== 'testMessage') broadcastEvent(name, message)
         },
@@ -126,7 +117,7 @@ class EventHandlers {
           this.textToSpeech.speak(text, voice, true)
         },
         toggleSwitch: async ({ switchName }) => {
-          return false
+          return this.controls.toggleSwitch({ switchName })
           /*
           // TODO Refactor this out into a dedicated library
           try {


### PR DESCRIPTION
DRAFT: because this only cover X11 with xdotool for now.
Next steps:
1) Support Wayland
2) Support Windows (SendInput)

Unfortunately I currently can't install other OS for testing 

---

I know the README says code contributions are not generally accepted, but since this moves toward a feature that appears to have been originally planned, I thought you might still be interested.

## Summary

This adds the missing control layer needed to make ship switches in the remote web UI interactive.

For now, the feature is opt-in and only implemented on Linux through `xdotool`. The control layer is separated from the platform-specific input backend, so support for another platform, such as Windows through `SendInput`, could be added later without reworking the UI.

The change:

* adds a controls service layer
* reads the active Elite Dangerous bindings file
* enables supported ship switches only when a keyboard binding is available
* sends the resolved key input through `xdotool` on Linux
* adds a **Settings → Controls** panel for viewing and refreshing detected bindings
* uses an explicit unsupported backend on other platforms

## Configuration

The feature is disabled by default and can be enabled with:

```env
ICARUS_ENABLE_CONTROLS=true
```

On Linux, it currently also requires:

* `xdotool`
* an X11 session

I have intentionally kept the change scoped, but I’m happy to adjust the structure if there is a preferred direction for this functionality.
